### PR TITLE
Wait for auth before sending helix requests

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.4.4
+
+- Calls to the new Twitch API will wait for auth tokens to be available
+
 # v2.4.3
 
 - Updated calls to the new Twitch API to use the latest authorization methods

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featured-follow-button",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Featured Follow Button",
   "repository": {
     "type": "git",

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -178,6 +178,7 @@ export async function getUserInfo(
   }
 
   try {
+    await Auth.authAvailable;
     const response: { data: Array<HelixUser> } = await fetch(
       "https://api.twitch.tv/helix/users?" + params,
       {


### PR DESCRIPTION
This should resolve an issue where the extension can sometimes send a request to helix before the auth tokens have arrived.